### PR TITLE
Add float:right class for menu items

### DIFF
--- a/css/kickstart-menus.css
+++ b/css/kickstart-menus.css
@@ -26,6 +26,11 @@ position:relative;z-index:1000;}
 /*--------------Dividers-------------------*/		
 	.menu ul li.divider{border-top:1px solid #ccc;}
 	.menu ul li.divider a{border-top:1px solid #fff;}
+
+
+/*--------------Right---------------------*/
+	.menu li.right{float:right;}
+
 	
 /*--------------Arrows-------------------*/
 	.menu li.has-menu a{padding-right:25px;}


### PR DESCRIPTION
Hi joshuagatcke :)

I added float:right class for menu li items.

Example:

``` css
<!-- Menu Horizontal -->
<ul class="menu">
        <li class="current"><a href="">Item 1</a></li>
        <li><a href="">Item 2</a></li>
        <li><a href=""><span class="icon" data-icon="R"></span>Item 3</a>

    <li class="right"><a href="#"><span class="icon" data-icon="u"></span>Account</a>
    <li class="right"><a href="#"><span class="icon" data-icon="Q"></span>Logout</a>                
</ul>
```

![Menu with right align items](http://f.cl.ly/items/1S0i3h1F2t1W0g3w3u2K/Снимок%20экрана%202012-07-09%20в%2011.39.04.jpg)

It's very useful and helpful option. KickStart users would appreciate this.
