### PR TITLE
Added hashtag URI identification for tabs

### DIFF
--- a/js/kickstart.js
+++ b/js/kickstart.js
@@ -258,6 +258,7 @@ jQuery(document).ready(function($){
 		tabs.removeClass('current');
 		$(this).parent().addClass('current');
 		$(tab_next).show();
+		history.pushState( null, null, window.location.search + $(this).attr('href') );
 		return false;
 	});
 	


### PR DESCRIPTION
Identifies if a hashtag exists in the URI of a page with tabs, and makes this the active tab
