### PR TITLE
Bug fix: img.caption was displayed at full-width instead of its actual width

### DIFF
--- a/css/kickstart.css
+++ b/css/kickstart.css
@@ -409,7 +409,7 @@ vertical-align: bottom;
 	background:#f5f5f5;
 	border:1px solid #ddd;
 	padding:3px;
-	width:100%;
+	display:inline-block;
 	height:auto;
 	}
 	


### PR DESCRIPTION
img.caption was displayed at full-width (100%) instead of its actual width (the image dimensions).
I'm not sure if it was a bug. Maybe it is a design choice I don't understand.
