### PR TITLE
Added ability to mix url tabs and hash tabs without generating an error on load

### DIFF
--- a/js/kickstart.js
+++ b/js/kickstart.js
@@ -73,7 +73,7 @@ jQuery(document).ready(function($){
 		var current = $(this).find('li.current');
 		if(current.length < 1) { $(this).find('li:first').addClass('current'); }
 		current = $(this).find('li.current a').attr('href');
-		$(current).show();
+		if(current.indexOf('#') == 0) $(current).show(); //allow mix matched  url tabs with hash tabs
 	});
 
 	// tab click


### PR DESCRIPTION
In one project I am working on I found the need to mix hash and url anchors using the .tabs class. When using a URL anchor they would display correctly but would generate console errors. The one liner simply checks to see of the href starts with a hash tag before triggering the show() method on document ready.
