### PR TITLE
Change google font to load over SSL

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
 /*---------------------------------
 	IMPORTS
 -----------------------------------*/
-@import url(http://fonts.googleapis.com/css?family=Arimo:400,700);
+@import url(https://fonts.googleapis.com/css?family=Arimo:400,700);
 
 /*---------------------------------
 	OVERRIDES


### PR DESCRIPTION
When using HTML-KickStart on an SSL site, the google font is loaded over HTTP giving an ssl warning. 