### PR TITLE
Correct typo in disabled selector for input and select

### DIFF
--- a/css/kickstart-forms.css
+++ b/css/kickstart-forms.css
@@ -106,7 +106,7 @@ box-sizing: border-box;
 
 	input::-moz-focus-inner {border:0;}
 
-	input[disabled="disabled"], input.disabled{
+	input[disabled="disabled"], input:disabled{
 	color:#999;
 	background:#f5f5f5;
 	-moz-box-shadow:inset 0 0 2px #ddd;
@@ -193,7 +193,7 @@ padding:3px;
 vertical-align: middle;
 }
 
-        select[disabled="disabled"], select.disabled{
+        select[disabled="disabled"], select:disabled{
         color:#999;
         background:#f5f5f5;
         -moz-box-shadow:inset 0 0 2px #ddd;


### PR DESCRIPTION
The selectors for input and select worked for disabled="disabled" but not when only using disabled. This commit changes the selector from input.disabled to input:disabled.